### PR TITLE
Simplify bridge between rely/deny and ds-auth

### DIFF
--- a/src/pause.sol
+++ b/src/pause.sol
@@ -15,6 +15,8 @@
 
 pragma solidity >=0.5.0 <0.6.0;
 
+import "ds-auth/auth.sol";
+
 contract DSPause {
     // --- Auth ---
     mapping (address => uint256) public wards;
@@ -97,4 +99,17 @@ contract DSPause {
         }
     }
 
+}
+
+// Utility contract to allow for easy integration with ds-auth based systems
+contract Scheduler is DSAuth {
+    DSPause pause;
+
+    constructor(DSPause pause_) public {
+        pause = pause_;
+    }
+
+    function schedule(address target, bytes memory data) public auth returns (bytes32) {
+        return pause.schedule(target, data);
+    }
 }


### PR DESCRIPTION
This commit introduces a small utility contract ([Scheduler](https://github.com/dapphub/ds-pause/compare/chief_upgrades...remove_governance_proxy?expand=1#diff-28b8f33e06097fd438d8e6ee06fcc3cdR105)) that can bridge between the rely/deny and ds-auth schemes.

This contract can replace the DSProxy that was previously being used for this purpose and can result in  more readable proposals ([example](https://github.com/dapphub/ds-pause/compare/chief_upgrades...remove_governance_proxy?expand=1#diff-fcc55ce71b4cc6941e7950034303000fR184)).