### PR TITLE
Explicit interfaces for cancel / execute

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,20 +22,20 @@ This can be useful as a security component within a governance system, to ensure
 - `guy` can no longer call methods restricted with `auth`
 - Subject to a delay (can only be called by using `schedule` and then `execute`)
 
-**`wards(address guy)`**
+**`wards(address guy) returns (uint)`**
 
 - Returns `1` if `guy` is an owner, `0` otherwise.
 
-**`schedule(address guy, bytes memory data) auth returns (bytes32 id)`**
+**`schedule(address guy, bytes memory data) auth returns (address, bytes memory, uint256)`**
 
 - Schedule a call with `data` calldata to address `guy`.
-- Returns the id needed to execute or cancel the call.
+- Returns all data needed to execute or cancel the scheduled call
 
-**`cancel(bytes32 id) auth`**
+**`cancel(address guy, bytes memory data, uint256 when) auth`**
 
 - Cancels a scheduled execution.
 
-**`execute(bytes32 id) returns (bytes memory response)`**
+**`execute(address guy, bytes memory data, uint256 when) returns (bytes memory response)`**
 
 - Executes the given function call (using `delegatecall`) as long as the delay period has passed.
 - Returns the `delegatecall` output

--- a/src/pause.sol
+++ b/src/pause.sol
@@ -22,27 +22,20 @@ contract DSPause {
     mapping (address => uint256) public wards;
 
     function rely(address guy) public {
-        require(msg.sender == address(this), "ds-pause: auth can only be updated through schedule/execute");
+        require(msg.sender == address(this), "ds-pause: rely can only be called by this contract");
         wards[guy] = 1;
     }
     function deny(address guy) public {
-        require(msg.sender == address(this), "ds-pause: auth can only be updated through schedule/execute");
+        require(msg.sender == address(this), "ds-pause: deny can only be called by this contract");
         wards[guy] = 0;
     }
-
     modifier auth {
         require(wards[msg.sender] == 1, "ds-pause: unauthorized");
         _;
     }
 
     // --- Data ---
-    struct Execution {
-        address  guy;
-        bytes    data;
-        uint256  timestamp;
-    }
-
-    mapping (bytes32 => Execution) public queue;
+    mapping (bytes32 => bool) public scheduled;
     uint256 public delay;
 
     // --- Init ---
@@ -51,39 +44,49 @@ contract DSPause {
         delay = delay_;
     }
 
-    // --- Authed ---
-    function schedule(address guy, bytes memory data) public auth returns (bytes32 id) {
-        require(guy != address(0), "ds-pause: cannot schedule calls to zero address");
-
-        id = keccak256(abi.encode(guy, data, now));
-
-        queue[id] = Execution({
-            guy: guy,
-            data: data,
-            timestamp: now
-        });
-
-        return id;
-    }
-
-    function cancel(bytes32 id) public auth {
-        delete queue[id];
+    // --- Internal ---
+    function tag(address guy, bytes memory data, uint256 when)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(guy, data, when));
     }
 
     // --- Public ---
-    function execute(bytes32 id) public payable returns (bytes memory response) {
-        Execution memory entry = queue[id];
-        require(now > entry.timestamp + delay, "ds-pause: delay not passed");
+    function schedule(address guy, bytes memory data)
+        public
+        auth
+        returns (address, bytes memory, uint256)
+    {
+        bytes32 id = tag(guy, data, now);
+        scheduled[id] = true;
+        return (guy, data, now);
+    }
 
-        require(entry.guy != address(0), "ds-pause: no scheduled execution for given id");
-        delete queue[id];
+    function cancel(address guy, bytes memory data, uint256 when)
+        public
+        auth
+    {
+        bytes32 id = tag(guy, data, when);
+        scheduled[id] = false;
+    }
 
-        address target = entry.guy;
-        bytes memory data = entry.data;
+    function execute(address guy, bytes memory data, uint256 when)
+        public
+        payable
+        returns (bytes memory response)
+    {
+        bytes32 id = tag(guy, data, when);
 
-        // call contract in current context
+        require(now > when + delay, "ds-pause: delay not passed");
+        require(scheduled[id] == true, "ds-pause: unscheduled execution");
+
+        scheduled[id] = false;
+
+        // delegatecall implementation from ds-proxy
         assembly {
-            let succeeded := delegatecall(sub(gas, 5000), target, add(data, 0x20), mload(data), 0, 0)
+            let succeeded := delegatecall(sub(gas, 5000), guy, add(data, 0x20), mload(data), 0, 0)
             let size := returndatasize
 
             response := mload(0x40)
@@ -93,12 +96,10 @@ contract DSPause {
 
             switch iszero(succeeded)
             case 1 {
-                // throw if delegatecall failed
                 revert(add(response, 0x20), size)
             }
         }
     }
-
 }
 
 // Utility contract to allow for easy integration with ds-auth based systems
@@ -109,7 +110,11 @@ contract Scheduler is DSAuth {
         pause = pause_;
     }
 
-    function schedule(address target, bytes memory data) public auth returns (bytes32) {
+    function schedule(address target, bytes memory data)
+        public
+        auth
+        returns (address, bytes memory, uint256)
+    {
         return pause.schedule(target, data);
     }
 }

--- a/src/pause.t.sol
+++ b/src/pause.t.sol
@@ -127,7 +127,7 @@ contract Auth is Test {
     function test_rely() public {
         assertEq(pause.wards(address(stranger)), 0);
 
-        bytes32 id = pause.schedule(
+        (address who, bytes memory data, uint256 when) = pause.schedule(
             address(ownership),
             abi.encodeWithSignature(
                 "rely(address,address)",
@@ -136,7 +136,7 @@ contract Auth is Test {
             )
         );
         hevm.warp(now + step);
-        pause.execute(id);
+        pause.execute(who, data, when);
 
         assertEq(pause.wards(address(stranger)), 1);
     }
@@ -144,7 +144,7 @@ contract Auth is Test {
     function test_deny() public {
         assertEq(pause.wards(address(this)), 1);
 
-        bytes32 id = pause.schedule(
+        (address who, bytes memory data, uint256 when) = pause.schedule(
             address(ownership),
             abi.encodeWithSignature(
                 "deny(address,address)",
@@ -153,7 +153,7 @@ contract Auth is Test {
             )
         );
         hevm.warp(now + step);
-        pause.execute(id);
+        pause.execute(who, data, when);
 
         assertEq(pause.wards(address(this)), 0);
     }
@@ -174,24 +174,28 @@ contract Auth is Test {
 
 contract Schedule is Test {
 
-    function testFail_cannot_schedule_zero_address() public {
-        pause.schedule(address(0), abi.encode(0));
-    }
-
     function testFail_call_from_non_owner() public {
         bytes memory data = abi.encodeWithSignature("schedule(address,bytes)", address(target), abi.encode(0));
         stranger.call(address(pause), data);
     }
 
-    function test_insertion() public {
+    function test_schedule() public {
+        bytes memory data = abi.encodeWithSignature("getBytes32()");
+
+        (address guy, bytes memory dataOut, uint256 when) = pause.schedule(address(target), data);
+
+        bytes32 id = keccak256(abi.encode(guy, dataOut, when));
+        assertTrue(pause.scheduled(id));
+    }
+
+    function test_return_data() public {
         bytes memory dataIn = abi.encodeWithSignature("getBytes32()");
 
-        bytes32 id = pause.schedule(address(target), dataIn);
-        (address guy, bytes memory dataOut, uint256 timestamp) = pause.queue(id);
+        (address guy, bytes memory dataOut, uint256 when) = pause.schedule(address(target), dataIn);
 
         assertEq0(dataIn, dataOut);
         assertEq(guy, address(target));
-        assertEq(timestamp, now);
+        assertEq(when, now);
     }
 
 }
@@ -199,23 +203,23 @@ contract Schedule is Test {
 contract Execute is Test {
 
     function testFail_delay_not_passed() public {
-        bytes32 id = pause.schedule(address(target), abi.encode(0));
-        pause.execute(id);
+        (address guy, bytes memory data, uint256 when) = pause.schedule(address(target), abi.encode(0));
+        pause.execute(guy, data, when);
     }
 
     function testFail_double_execution() public {
-        bytes32 id = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
+        (address guy, bytes memory data, uint256 when) = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
         hevm.warp(now + step);
 
-        pause.execute(id);
-        pause.execute(id);
+        pause.execute(guy, data, when);
+        pause.execute(guy, data, when);
     }
 
     function test_execute_delay_passed() public {
-        bytes32 id = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
+        (address guy, bytes memory data, uint256 when) = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
         hevm.warp(now + step);
 
-        bytes memory response = pause.execute(id);
+        bytes memory response = pause.execute(guy, data, when);
 
         bytes32 response32;
         assembly {
@@ -225,10 +229,10 @@ contract Execute is Test {
     }
 
     function test_call_from_non_owner() public {
-        bytes32 id = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
+        (address guy, bytes memory data, uint256 when) = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
         hevm.warp(now + step);
 
-        stranger.call(address(pause), abi.encodeWithSignature("execute(bytes32)", id));
+        stranger.call(address(pause), abi.encodeWithSignature("execute(address,bytes,uint256)", guy, data, when));
     }
 
 }
@@ -236,23 +240,21 @@ contract Execute is Test {
 contract Cancel is Test {
 
     function testFail_call_from_non_owner() public {
-        bytes32 id = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
+        (address guy, bytes memory data, uint256 when) = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
         hevm.warp(now + step);
 
-        bytes memory data = abi.encodeWithSignature("cancel(bytes32)", id);
-        stranger.call(address(pause), data);
+        bytes memory cancelData = abi.encodeWithSignature("cancel(address,bytes,uint256)", guy, data, when);
+        stranger.call(address(pause), cancelData);
     }
 
     function test_cancel_scheduled_execution() public {
-        bytes32 id = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
+        (address guy, bytes memory data, uint256 when) = pause.schedule(address(target), abi.encodeWithSignature("getBytes32()"));
         hevm.warp(now + step);
 
-        pause.cancel(id);
+        pause.cancel(guy, data, when);
 
-        (address guy, bytes memory data, uint256 timestamp) = pause.queue(id);
-        assertEq(guy, address(0));
-        assertEq0(data, new bytes(0));
-        assertEq(timestamp, 0);
+        bytes32 id = keccak256(abi.encode(guy, data, when));
+        assertTrue(!pause.scheduled(id));
     }
 
 }


### PR DESCRIPTION
Explicit interfaces for cancel / execute protects users from attacks where their transactions are replayed against a reorged / eclipsed chain, as a modification to the state of the chain cannot change the semantic meaning of their transaction.