### PR TITLE
Use solidity delegatecall

### DIFF
--- a/src/pause.sol
+++ b/src/pause.sol
@@ -96,24 +96,12 @@ contract DSPauseProxy {
 
     function exec(address usr, bytes memory fax)
         public
-        returns (bytes memory response)
+        returns (bytes memory out)
     {
         require(msg.sender == owner, "ds-pause-proxy-unauthorized");
 
-        // delegatecall implementation from ds-proxy
-        assembly {
-            let succeeded := delegatecall(sub(gas, 5000), usr, add(fax, 0x20), mload(fax), 0, 0)
-            let size := returndatasize
-
-            response := mload(0x40)
-            mstore(0x40, add(response, and(add(add(size, 0x20), 0x1f), not(0x1f))))
-            mstore(response, size)
-            returndatacopy(add(response, 0x20), 0, size)
-
-            switch iszero(succeeded)
-            case 1 {
-                revert(add(response, 0x20), size)
-            }
-        }
+        bool ok;
+        (ok, out) = usr.delegatecall(fax);
+        require(ok, "ds-pause-delegatecall-error");
     }
 }


### PR DESCRIPTION
Since version 0.5.0, the solidity `delegatecall` returns the result of the call, so the assembly implementation from `ds-proxy` is no longer needed.

@rainbreak you had some concerns about using the solidity `delegatecall` when we discussed this previously. What needs to be done in terms of bytecode auditing etc.?