### PR TITLE
Switch from rely/deny to ds-auth

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,27 +4,17 @@ _schedule function calls that can only be executed after some predetermined dela
 
 This can be useful as a security component within a governance system, to ensure that those affected by governance decisions have time to react in the case of an attack.
 
+## Auth
+
+`ds-pause` uses a slightly modified form of the `ds-auth` scheme. Both `setOwner` and `setAuthority`
+can only be called by the pause itself. This means that they can only be called by using `schedule` /
+`execute` on the pause, and changes to auth are therefore also subject to a delay.
+
 ## Interface
 
 **`constructor(uint256 delay)`**
 
 - Initializes a new instance of the contract with a delay in ms
-
-**`rely(address guy)`**
-
-- Add `guy` as an owner
-- `guy` can now call methods restricted with `auth`
-- Subject to a delay (can only be called by using `schedule` and then `execute`)
-
-**`deny(address guy)`**
-
-- Remove `guy` from the owners list
-- `guy` can no longer call methods restricted with `auth`
-- Subject to a delay (can only be called by using `schedule` and then `execute`)
-
-**`wards(address guy) returns (uint)`**
-
-- Returns `1` if `guy` is an owner, `0` otherwise.
 
 **`schedule(address guy, bytes memory data) auth returns (address, bytes memory, uint256)`**
 
@@ -43,4 +33,4 @@ This can be useful as a security component within a governance system, to ensure
 ## Tests
 
 - [`pause.t.sol`](./pause.t.sol): unit tests
-- [`integration.t.sol`](./integration.t.sol): basic usage example / integation tests
+- [`integration.t.sol`](./integration.t.sol): usage examples / integation tests

--- a/src/pause.sol
+++ b/src/pause.sol
@@ -20,14 +20,12 @@ import "ds-auth/auth.sol";
 contract DSPause is DSAuth {
     // --- Auth ---
     function setOwner(address owner_) public {
-        require(msg.sender == address(this));
-        owner = owner_;
-        emit LogSetOwner(owner);
+        require(msg.sender == address(this), "ds-pause: changes to ownership must be delayed");
+        super.setOwner(owner_);
     }
-    function setAuthority(DSAuthority guy) public {
-        require(msg.sender == address(this));
-        authority = guy;
-        emit LogSetAuthority(address(authority));
+    function setAuthority(DSAuthority authority_) public {
+        require(msg.sender == address(this), "ds-pause: changes to authority must be delayed");
+        super.setAuthority(authority_);
     }
 
     // --- Data ---


### PR DESCRIPTION
I'm not 100% sure about this change, since `ds-auth` is more complex than I would like, but I think the reduction in the number of modules and auth connections is probably worth it.

Modules using `rely`/`deny` for auth must make use of a proxy or 'bridge' contract to interface with modules that use the `ds-auth` scheme.

Since the rest of dappsys (including `ds-chief` which this module should interface well with) uses `ds-auth`, a non trivial reduction in deployment and auth complexity can be realised by replacing `rely`/`deny` with `ds-auth`, and doing away with the bridge contracts.

This doesn't make much of a difference to the readability of the governance proposals themselves, and it will also make upgrading to a chief that does not use `ds-auth` in the future (quite likely) more complex.

The below diagram compares the two auth schemes.

![diagram](https://user-images.githubusercontent.com/6689924/53640718-3280af80-3c2d-11e9-8283-aaf52fce9eb1.jpg)
