### PR TITLE
Fully explicit interface for plan

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,24 +12,26 @@ can only be called by the pause itself. This means that they can only be called 
 
 ## Interface
 
-**`constructor(uint256 delay)`**
+**`constructor(uint delay)`**
 
 - Initializes a new instance of the contract with a delay in ms
 
-**`plan(address usr, bytes memory fax) auth returns (address, bytes memory, uint256)`**
+**`plan(address usr, bytes memory fax uint era) public auth`**
 
-- Plan a call to address `usr` with `fax` calldata
+- Plan a call to address `usr` with `fax` calldata that cannot be executed until `block.timestamp >=
+  era`
+- Fails if `block.timestamp + delay > era`
 - Returns all data needed to execute or cancel the scheduled call
 
-**`drop(address usr, bytes memory fax, uint256 era) auth`**
+**`drop(address usr, bytes memory fax, uint era) public auth`**
 
 - Cancels a planned execution
 
-**`exec(address usr, bytes memory fax, uint256 era) returns (bytes memory response)`**
+**`exec(address usr, bytes memory fax, uint era) public returns (bytes memory response)`**
 
 - `delegatecall` into `usr` with `fax` calldata
-- fails if the call has not been planned beforehand
-- fails if the delay period has not passed
+- Fails if the call has not been planned beforehand
+- Fails if `era > block.timestamp`
 - Returns the `delegatecall` output
 
 ## Tests

--- a/src/pause.sol
+++ b/src/pause.sol
@@ -61,16 +61,16 @@ contract DSPause is DSAuth {
     }
 
     // --- executions ---
-    function plan(address usr, bytes memory fax)
+    function plan(address usr, bytes memory fax, uint era)
         public
         auth
-        returns (address, bytes memory, uint)
     {
-        bytes32 id  = hash(usr, fax, now);
+        require(era >= add(now, delay), "ds-pause-delay-not-respected");
+
+        bytes32 id  = hash(usr, fax, era);
         planned[id] = true;
 
-        emit Plan(usr, fax, now);
-        return (usr, fax, now);
+        emit Plan(usr, fax, era);
     }
 
     function drop(address usr, bytes memory fax, uint era)
@@ -89,8 +89,8 @@ contract DSPause is DSAuth {
     {
         bytes32 id = hash(usr, fax, era);
 
-        require(now >= add(era, delay), "ds-pause-delay-not-elapsed");
-        require(planned[id] == true,    "ds-pause-unplanned-execution");
+        require(now >= era,          "ds-pause-execution-too-soon");
+        require(planned[id] == true, "ds-pause-unplanned-execution");
 
         planned[id] = false;
 


### PR DESCRIPTION
`era` must now be passed in as an argument to plan.

This has a few benefits:

1. Fully explicit interface (protects against replay attacks during a reorg / eclipse)
2. Reduces gas costs (don't need to return anything now)
3. Makes the pause a little more generic / flexible