### PR TITLE
Document invariants. Rename plan -> plot.

### DIFF
--- a/src/integration.t.sol
+++ b/src/integration.t.sol
@@ -96,7 +96,7 @@ contract Proposal {
         done = true;
 
         uint era = now + pause.delay();
-        pause.plan(action, payload, era);
+        pause.plot(action, payload, era);
         return (action, payload, era);
     }
 }
@@ -208,7 +208,7 @@ contract Guard is DSAuthority {
     function canCall(address src, address dst, bytes4 sig) public view returns (bool) {
         require(src == address(this));
         require(dst == address(pause));
-        require(sig == bytes4(keccak256("plan(address,bytes,uint256)")));
+        require(sig == bytes4(keccak256("plot(address,bytes,uint256)")));
         return true;
     }
 
@@ -219,7 +219,7 @@ contract Guard is DSAuthority {
         bytes memory fax = abi.encodeWithSignature( "set(address,address)", pause, newAuthority);
         uint         era = now + pause.delay();
 
-        pause.plan(usr, fax, era);
+        pause.plot(usr, fax, era);
         return (usr, fax, era);
     }
 }

--- a/src/pause.sol
+++ b/src/pause.sol
@@ -55,7 +55,7 @@ contract DSPause is DSAuth, DSNote {
     }
 
     // --- executions ---
-    function plan(address usr, bytes memory fax, uint eta)
+    function plot(address usr, bytes memory fax, uint eta)
         public note auth
     {
         require(eta >= add(now, delay), "ds-pause-delay-not-respected");
@@ -73,7 +73,7 @@ contract DSPause is DSAuth, DSNote {
         returns (bytes memory response)
     {
         require(now >= eta,                 "ds-pause-premature-execution");
-        require(plans[hash(usr, fax, eta)], "ds-pause-unplanned-execution");
+        require(plans[hash(usr, fax, eta)], "ds-pause-unplotted-execution");
 
         plans[hash(usr, fax, eta)] = false;
 

--- a/src/pause.t.sol
+++ b/src/pause.t.sol
@@ -35,7 +35,7 @@ contract Target {
 
 contract Stranger {
     function plan(DSPause pause, address usr, bytes memory fax, uint eta) public {
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
     }
     function drop(DSPause pause, address usr, bytes memory fax, uint eta) public {
         pause.drop(usr, fax, eta);
@@ -138,7 +138,7 @@ contract Auth is Test {
         bytes memory fax = abi.encodeWithSignature("set(address,address)", pause, 0xdeadbeef);
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
         hevm.warp(eta);
         pause.exec(usr, fax, eta);
 
@@ -156,7 +156,7 @@ contract Auth is Test {
         bytes memory fax = abi.encodeWithSignature("set(address,address)", pause, newAuthority);
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
         hevm.warp(eta);
         pause.exec(usr, fax, eta);
 
@@ -179,7 +179,7 @@ contract Plan is Test {
         bytes memory fax = abi.encodeWithSignature("get()");
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
 
         bytes32 id = keccak256(abi.encode(usr, fax, eta));
         assertTrue(pause.plans(id));
@@ -194,7 +194,7 @@ contract Exec is Test {
         bytes memory fax = abi.encode(0);
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
         pause.exec(usr, fax, eta);
     }
 
@@ -203,7 +203,7 @@ contract Exec is Test {
         bytes memory fax = abi.encodeWithSignature("get()");
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
         hevm.warp(eta);
         pause.exec(usr, fax, eta);
         pause.exec(usr, fax, eta);
@@ -214,7 +214,7 @@ contract Exec is Test {
         bytes memory fax = abi.encodeWithSignature("get()");
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
         hevm.warp(eta);
         bytes memory out = pause.exec(usr, fax, eta);
 
@@ -226,7 +226,7 @@ contract Exec is Test {
         bytes memory fax = abi.encodeWithSignature("get()");
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
         hevm.warp(eta);
 
         bytes memory out = stranger.exec(pause, usr, fax, eta);
@@ -243,7 +243,7 @@ contract Drop is Test {
         bytes memory fax = abi.encodeWithSignature("get()");
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
         hevm.warp(eta);
 
         stranger.drop(pause, usr, fax, eta);
@@ -254,7 +254,7 @@ contract Drop is Test {
         bytes memory fax = abi.encodeWithSignature("get()");
         uint         eta = now + pause.delay();
 
-        pause.plan(usr, fax, eta);
+        pause.plot(usr, fax, eta);
 
         hevm.warp(eta);
         pause.drop(usr, fax, eta);


### PR DESCRIPTION
Describe data format & invariants. Renamed `plan` to `plot` because it was previously being used as both a verb and a noun, making it very hard to describe the invariants in a concise way.