### PR TITLE
Isolated storage for delegatecall

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,18 @@ Plans can be manipulated in the following ways:
 **storage**
 - Auth can only be changed if an authorized user plots a `plan` to do so
 - The `delay` can only be changed if an authorized user plots a `plan` to do so
+- Storage can only be modified through use of the publicly exposed methods
+- The pause will always retain ownership of it's `proxy`
+
+## Identity & Trust
+
+In order to protect the internal storage of the pause from malicious writes during `plan` execution,
+we perform the actual `delegatecall` operation in a seperate contract with an isolated storage
+context (`DSPauseProxy`). Each pause has it's own individual `proxy`.
+
+This means that `plan`'s are executed with the identity of the `proxy`, and when integrating the
+pause into some auth scheme, you probably want to trust the pause's `proxy` and not the pause
+itself.
 
 ## Example Usage
 
@@ -81,3 +93,4 @@ bytes memory out = pause.exec(usr, fax, eta);
 
 - [`pause.t.sol`](./pause.t.sol): unit tests
 - [`integration.t.sol`](./integration.t.sol): usage examples / integation tests
+

--- a/src/integration.t.sol
+++ b/src/integration.t.sol
@@ -158,7 +158,7 @@ contract Voting is Test {
         // create gov system
         DSChief chief = chiefFab.newChief(gov, maxSlateSize);
         DSPause pause = new DSPause(delay, address(0x0), chief);
-        target.rely(address(pause));
+        target.rely(address(pause.proxy()));
         target.deny(address(this));
 
         // create proposal
@@ -233,7 +233,7 @@ contract UpgradeChief is Test {
         DSPause pause = new DSPause(delay, address(0x0), oldChief);
 
         // make pause the only owner of the target
-        target.rely(address(pause));
+        target.rely(address(pause.proxy()));
         target.deny(address(this));
 
         // create new chief

--- a/src/pause.t.sol
+++ b/src/pause.t.sol
@@ -28,6 +28,11 @@ contract Hevm {
 }
 
 contract Target {
+    address owner;
+    function give(address usr) public {
+        owner = usr;
+    }
+
     function get() public pure returns (bytes32) {
         return bytes32("Hello");
     }
@@ -206,6 +211,16 @@ contract Exec is Test {
         pause.plot(usr, fax, eta);
         hevm.warp(eta);
         pause.exec(usr, fax, eta);
+        pause.exec(usr, fax, eta);
+    }
+
+    function testFail_exec_plan_with_proxy_ownership_change() public {
+        address      usr = target;
+        bytes memory fax = abi.encodeWithSignature("give(address)", address(this));
+        uint         eta = now + pause.delay();
+
+        pause.plot(usr, fax, eta);
+        hevm.warp(eta);
         pause.exec(usr, fax, eta);
     }
 


### PR DESCRIPTION
The code executed by delegatecall has complete access to the pause's storage. This is messy and makes plans hard to audit as they can potentially do some pretty sneaky stuff (e.g. bypass the delay by writing directly to the `plans` mapping).

In this change we pull the code that does the actual `delegatecall` out into its own contract (`Delegator`), making it impossible for the `delegatecall` to directly modify the storage of the pause without going through the defined interfaces.

Another additional benefit to this change is that the `msg.sender` of the `delegatecall` is no longer under the control of the caller to `exec`.

An additional check in `exec` is also required to make sure that the storage of the `delegator` itself remains unmodified.

This change does probably make reasoning about the pause and its place in some auth scheme a little harder as it now effectively has two identities (`DSPause` & `Delegator`).