### PR TITLE
Remove eta from the interface to plot

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ Plans can be manipulated in the following ways:
 ## Invariants
 
 **`plot`**
-- A `plan` can only be plotted if its `eta` is after `block.timestamp + delay`
 - A `plan` can only be plotted by authorized users
+- Plotted `plan`s will always have an `eta` of `block.timestamp + delay`
 
 **`exec`**
 - A `plan` can only be executed if it has previously been plotted
@@ -77,9 +77,8 @@ DSPause pause = new DSPause(delay, owner, authority);
 
 address      usr = address(0x0);
 bytes memory fax = abi.encodeWithSignature("sig()");
-uint         eta = now + delay;
 
-pause.plot(usr, fax, eta);
+uint eta = pause.plot(usr, fax);
 ```
 
 ```solidity

--- a/src/integration.t.sol
+++ b/src/integration.t.sol
@@ -95,8 +95,7 @@ contract Proposal {
         require(!done);
         done = true;
 
-        uint eta = now + pause.delay();
-        pause.plot(usr, fax, eta);
+        uint eta = pause.plot(usr, fax);
         return (usr, fax, eta);
     }
 }
@@ -211,7 +210,7 @@ contract Guard is DSAuthority {
     function canCall(address src, address dst, bytes4 sig) public view returns (bool) {
         require(src == address(this));
         require(dst == address(pause));
-        require(sig == bytes4(keccak256("plot(address,bytes,uint256)")));
+        require(sig == bytes4(keccak256("plot(address,bytes)")));
         return true;
     }
 
@@ -220,9 +219,8 @@ contract Guard is DSAuthority {
 
         address      usr = address(new SetAuthority());
         bytes memory fax = abi.encodeWithSignature( "set(address,address)", pause, newAuthority);
-        uint         eta = now + pause.delay();
 
-        pause.plot(usr, fax, eta);
+        uint eta = pause.plot(usr, fax);
         return (usr, fax, eta);
     }
 }

--- a/src/pause.sol
+++ b/src/pause.sol
@@ -59,10 +59,11 @@ contract DSPause is DSAuth, DSNote {
     }
 
     // --- executions ---
-    function plot(address usr, bytes memory fax, uint eta)
+    function plot(address usr, bytes memory fax)
         public note auth
+        returns (uint eta)
     {
-        require(eta >= add(now, delay), "ds-pause-delay-not-respected");
+        eta = add(now, delay);
         plans[hash(usr, fax, eta)] = true;
     }
 


### PR DESCRIPTION
As discussed in https://github.com/makerdao/dss-deploy/pull/19#issuecomment-481791449 there are some UX issues around having users specify `eta` up front when plotting plans. If plotting a plan off chain using e.g. `seth`,  then users didn't know the timestamp of the block that the transaction would be mined in, so had to guess at a suitable value of `eta` that would still be greater than `now + delay` for whatever block the transaction was included in.

This commit removes `eta` from the interface to `plot` and instead has it always set to `now + delay`.

There are some security implications, and the removal of  `eta` from the interface to `plot` would allow an [eclipse](https://www.usenix.org/node/190891) capable attacker to:

- bypass the delay (assuming access to very large amounts of hashpower)
- reorder plans (assuming plans are being plotted by multiple users)
- execute the same plan multiple times (assuming a little social engineering)

These attacks are all highly resource intensive, and complex to pull off. It may be that the UX gains are worth the security trade offs, but I'm not 100% sure. Interested to hear other opinions.

## Security Impact

The removal of `eta` from the interface changes the security posture of the pause against eclipse / replay attacks.

More details on eclipse attacks can be found in the paper here: https://www.usenix.org/node/190891

I consider the following scenario:

- There are multiple entities who are authorized to plot plans.
- There exists an attacker that has sufficient control over the network layer to force partitions
  and perform eclipse attacks.
- The attacker has access to significant hashpower (enough to force reorgs)

Note that for the purposes of this analysis I consider the pause in isolation and do not consider the security of the whole integrated Maker governance system against eclipse attacks.

### Attacks

#### Delay Bypass

If the attacker has majority hashpower on each side of the partition, they could capture the `plot` transaction, rewind the chain, and include the tx in a block with an earlier timestamp. They could then set the timestamp of the next block to the current time, allowing for immediate execution.

This attack is obviously extremely resource intensive, requiring an attacker that has access to a huge amount of hashpower, as well as enough control over the network to run eclipse attacks. The cost scales linearly with the delay (the delay length determines how far back the attackers will have to rewind and then rebuild on top of).

This attack would not be possible if `eta` remained in the interface (rewinding the blockchain would not affect the plans `eta`).

#### Plan Reordering

I hypothesise here a situation where two plans are to be plotted. Each `plan` will be plotted by a different user. If the second `plan` is executed before the first, then bad stuff will happen.

The attacker can partition the users onto a minority chain, capture their `plot` transactions and then replay them out of order on the majority chain.

This attack would not be possible if `eta` remained in the interface (the attacker would have no control over the `eta` of the `plan`).

The plans would still remain subject to the delay, and affected parties would have time to engage whatever additional countermeasures they have available to them.

#### Multiple Executions

I hypothesise here a situation where there is a single plan to be plotted. If the plan is executed more than once, then bad stuff will happen.

An attacker with eclipse power could intercept and hold `plot` transactions's from the owner. The owner may assume some network issue and submit the same tx again (perhaps with an increased nonce). The attacker could then relay both transactions to miners.

This attack would not be possible if `eta` remained in the interface (both transactions would refer to the exact same plan).

The plans would still remain subject to the delay, and affected parties would have time to engage whatever additional countermeasures they have available to them.
