### PR TITLE
Specify codehash in plans

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ cannot be executed.
 A `plan` consists of:
 
 - `usr`: address to `delegatecall` into
+- `tag`: the expected codehash of `usr`
 - `fax`: `calldata` to use
 - `eta`: first possible (unix) time of execution
 
@@ -51,6 +52,7 @@ to security@dapp.org.
 **`exec`**
 - A `plan` can only be executed if it has previously been plotted
 - A `plan` can only be executed once it's `eta` has passed
+- A `plan` can only be executed if its `tag` matches `extcodehash(usr)`
 - A `plan` can only be executed once
 - A `plan` can be executed by anyone
 
@@ -81,17 +83,18 @@ DSPause pause = new DSPause(delay, owner, authority);
 // plot the plan
 
 address      usr = address(0x0);
+bytes32      tag;  assembly { tag := extcodehash(usr) }
 bytes memory fax = abi.encodeWithSignature("sig()");
 uint         eta = now + delay;
 
-pause.plot(usr, fax, eta);
+pause.plot(usr, tag, fax, eta);
 ```
 
 ```solidity
 // wait until block.timestamp is at least now + delay...
 // and then execute the plan
 
-bytes memory out = pause.exec(usr, fax, eta);
+bytes memory out = pause.exec(usr, tag, fax, eta);
 ```
 
 ## Tests


### PR DESCRIPTION
Since the introduction of the `CREATE2` opcode we can no longer assume that the same address will always contain the same code ([details](https://ethereum-magicians.org/t/potential-security-implications-of-create2-eip-1014/2614)).

Here, we defend against this attack by forcing callers of `plot` to specify the expected codehash of `usr` (the `tag`). When `exec` is called, the codehash is compared to the `tag`, and `exec` will revert if they do not match.
