### PR TITLE
Runtime configurable delay

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,8 @@ to security@dapp.org.
 - The code executed by the `delegatecall` cannot directly modify storage on the pause
 - The pause will always retain ownership of it's `proxy`
 
-**auth**
-- `authority` and `owner` can only be changed if an authorized user plots a `plan` to do so
+**admin**
+- `authority`, `owner`, and `delay` can only be changed if an authorized user plots a `plan` to do so
 
 **`plot`**
 - A `plan` can only be plotted if its `eta` is after `block.timestamp + delay`

--- a/src/pause.sol
+++ b/src/pause.sol
@@ -19,16 +19,20 @@ import {DSNote} from "ds-note/note.sol";
 import {DSAuth, DSAuthority} from "ds-auth/auth.sol";
 
 contract DSPause is DSAuth, DSNote {
-    // --- auth ---
-    function setOwner(address owner_) public {
-        require(msg.sender == address(proxy), "ds-pause-undelayed-ownership-change");
+    // --- admin ---
+    modifier wait() {
+        require(msg.sender == address(proxy), "ds-pause-undelayed-call"); _;
+    }
+    function setOwner(address owner_) public wait {
         owner = owner_;
         emit LogSetOwner(owner);
     }
-    function setAuthority(DSAuthority authority_) public {
-        require(msg.sender == address(proxy), "ds-pause-undelayed-authority-change");
+    function setAuthority(DSAuthority authority_) public wait {
         authority = authority_;
         emit LogSetAuthority(address(authority));
+    }
+    function setDelay(uint delay_) public note wait {
+        delay = delay_;
     }
 
     // --- math ---


### PR DESCRIPTION
Authorized users can now plot plans that will update the delay when executed.