### PR TITLE
Remove proxy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,11 +41,6 @@ Plans can be manipulated in the following ways:
 A break of any of the following would be classified as a critical issue. Please submit bug reports
 to security@dapp.org.
 
-**high level**
-- There is no way to bypass the delay
-- The code executed by the `delegatecall` cannot directly modify storage on the pause
-- The pause will always retain ownership of it's `proxy`
-
 **admin**
 - `authority`, `owner`, and `delay` can only be changed if an authorized user plots a `plan` to do so
 
@@ -63,15 +58,13 @@ to security@dapp.org.
 **`drop`**
 - A `plan` can only be dropped by authorized users
 
-## Identity & Trust
+## Gotchas
 
-In order to protect the internal storage of the pause from malicious writes during `plan` execution,
-we perform the actual `delegatecall` operation in a seperate contract with an isolated storage
-context (`DSPauseProxy`). Each pause has it's own individual `proxy`.
-
-This means that `plan`'s are executed with the identity of the `proxy`, and when integrating the
-pause into some auth scheme, you probably want to trust the pause's `proxy` and not the pause
-itself.
+Plans are executed with `delegatecall`, this means they have full write access to the pause's
+storage. This access can be used to bypass the checks in `plot` and make plans that can be executed
+less than `delay` seconds into the future. Because `plot` is only callable by authorized users, and
+a malicous plan could anyway just take ownership of the pause entirely, it was decided that counter
+measures were not worth the additional complexity.
 
 ## Example Usage
 
@@ -95,8 +88,7 @@ pause.plot(usr, tag, fax, eta);
 ```
 
 ```solidity
-// wait until block.timestamp is at least now + delay...
-// and then execute the plan
+// wait until block.timestamp is at least now + delay and then execute the plan
 
 bytes memory out = pause.exec(usr, tag, fax, eta);
 ```

--- a/src/integration.t.sol
+++ b/src/integration.t.sol
@@ -165,7 +165,7 @@ contract Voting is Test {
         // create gov system
         DSChief chief = chiefFab.newChief(gov, maxSlateSize);
         DSPause pause = new DSPause(delay, address(0x0), chief);
-        target.rely(address(pause.proxy()));
+        target.rely(address(pause));
         target.deny(address(this));
 
         // create proposal
@@ -272,7 +272,7 @@ contract UpgradeChief is Test {
         DSPause pause = new DSPause(delay, address(0x0), oldChief);
 
         // make pause the only owner of the target
-        target.rely(address(pause.proxy()));
+        target.rely(address(pause));
         target.deny(address(this));
 
         // create new chief

--- a/src/pause.t.sol
+++ b/src/pause.t.sol
@@ -276,17 +276,6 @@ contract Exec is Test {
         pause.exec(usr, tag, fax, eta);
     }
 
-    function testFail_exec_plan_with_proxy_ownership_change() public {
-        address      usr = target;
-        bytes32      tag = extcodehash(usr);
-        bytes memory fax = abi.encodeWithSignature("give(address)", address(this));
-        uint         eta = now + pause.delay();
-
-        pause.plot(usr, tag, fax, eta);
-        hevm.warp(eta);
-        pause.exec(usr, tag, fax, eta);
-    }
-
     function test_suceeds_when_delay_passed() public {
         address      usr = target;
         bytes32      tag = extcodehash(usr);


### PR DESCRIPTION
As far as I can tell, the `proxy` only protects against one edge case attack (a malicous plan could write directly to the `plans` mapping, allowing it to create plans that can executed with no delay). All other storage locations are exposed on interfaces that require only that they are being called from a `plan`.

The only case that I can see where this would give an attacker a real advantage is if there was an attack that could only be composed of multiple simulatneous transactions executed with the identity of the pause.

Given that `plot` is authed and a malcious plan could anyway take ownership of the entire pause, I think that the risk introduced by the additional implementation complexity that this countermeasure requires is greater than the risk of allowing this particular attack.

This does mean losing one nice invariant: 'There is no way to bypass the delay'.

Am I missing something?

cc @kmbarry1 @iamchrissmith @gbalabasquer